### PR TITLE
shift notifier to parent component

### DIFF
--- a/lib/core/viewmodels/community_search_model.dart
+++ b/lib/core/viewmodels/community_search_model.dart
@@ -31,9 +31,10 @@ class CommunitySearchModel extends ChangeNotifier {
       _communities = _api.searchCommunities().where((c) =>
         c.name.toLowerCase().contains(query.toLowerCase())
       ).toList();
+    } else {
+      _communities = _api.searchCommunities();
     }
 
-    print('communities length = ' + _communities.length.toString());
     notifyListeners();
   }
 }

--- a/lib/ui/components/Inputs/Search/search_row.dart
+++ b/lib/ui/components/Inputs/Search/search_row.dart
@@ -36,7 +36,6 @@ class _SearchRowState extends State<SearchRow> {
   }
 
   void setSearchFocused() {
-    print('set search focused');
     isSearchFocused = !isSearchFocused;
     setState(() => {});
   }

--- a/lib/ui/screens/Communities/community_search_bar.dart
+++ b/lib/ui/screens/Communities/community_search_bar.dart
@@ -1,44 +1,38 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import 'package:baloo/ui/components/Inputs/Search/search_row.dart';
-import 'package:baloo/ui/components/base_data_widget.dart';
-
-// Models
-import 'package:baloo/core/viewmodels/community_search_model.dart';
 
 
 class CommunitySearchBar extends StatelessWidget {
+  final Function search;
+
+  CommunitySearchBar({ @required this.search });
+
   @override
   Widget build(BuildContext context) {
-    return BaseDataWidget<CommunitySearchModel>(
-      model: CommunitySearchModel(api: Provider.of(context)),
-      onModelReady: (model) => { /* TODO mjf: fetch data */ },
-      builder: (context, search, child) =>
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            Container (
-              height: 40,
-              margin: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 4.0),
-              child: Text(
-                'Discover',
-                textDirection: TextDirection.ltr,
-                textAlign: TextAlign.left,
-                style: TextStyle(
-                  color: Color(0xFF2F2F33),
-                  fontFamily: 'Muli',
-                  fontWeight: FontWeight.w700,
-                  fontSize: 32,
-                ),
-              ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Container (
+          height: 40,
+          margin: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 4.0),
+          child: Text(
+            'Discover',
+            textDirection: TextDirection.ltr,
+            textAlign: TextAlign.left,
+            style: TextStyle(
+              color: Color(0xFF2F2F33),
+              fontFamily: 'Muli',
+              fontWeight: FontWeight.w700,
+              fontSize: 32,
             ),
-            SearchRow(
-              search: search.searchCommunities,
-              filters: ['Nearby', 'Popular', 'Newest'],
-            ),
-          ],
+          ),
         ),
+        SearchRow(
+          search: search,
+          filters: ['Nearby', 'Popular', 'Newest'],
+        ),
+      ],
     );
   }
 }

--- a/lib/ui/screens/Communities/community_search_results.dart
+++ b/lib/ui/screens/Communities/community_search_results.dart
@@ -1,31 +1,25 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import 'package:baloo/ui/screens/Communities/community_listitem.dart';
-import 'package:baloo/ui/components/base_data_widget.dart';
 
 // Models
-import 'package:baloo/core/viewmodels/community_search_model.dart';
+import 'package:baloo/core/models/community.dart';
 
 
 class CommunitySearchResults extends StatelessWidget{
+  final List<Community> communities;
+
+  CommunitySearchResults({ @required this.communities });
+
   @override
   Widget build(BuildContext context) {
-    return BaseDataWidget<CommunitySearchModel>(
-      model: CommunitySearchModel(api: Provider.of(context)),
-      onModelReady: (model) => { /* TODO mjf: fetch data */ },
-      builder: (context, communities, child) {
-        print('build communities length = ' + communities.communities.length.toString());
-
-        return SliverList(
-          delegate: SliverChildBuilderDelegate(
-            (BuildContext context, int index) {
-              return CommunityListItem(community: communities.communities[index]);
-            },
-            childCount: communities.length,
-          ),
-        );
-      }
+    return SliverList(
+      delegate: SliverChildBuilderDelegate(
+        (BuildContext context, int index) {
+          return CommunityListItem(community: communities[index]);
+        },
+        childCount: communities.length,
+      ),
     );
   }
 }

--- a/lib/ui/screens/communities_screen.dart
+++ b/lib/ui/screens/communities_screen.dart
@@ -1,12 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import 'package:baloo/core/constants/routes.dart';
+import 'package:baloo/ui/components/base_data_widget.dart';
 import 'package:baloo/ui/screens/Communities/user_communities_list.dart';
 import 'package:baloo/ui/screens/Communities/community_search_results.dart';
 import 'package:baloo/ui/screens/Communities/community_search_bar.dart';
 
 import 'package:baloo/ui/components/Navigation/nav_bar.dart';
 import 'package:baloo/ui/components/Navigation/nav_action_button.dart';
+
+// Models
+import 'package:baloo/core/viewmodels/community_search_model.dart';
 
 
 class CommunitiesScreen extends StatelessWidget{
@@ -20,12 +25,17 @@ class CommunitiesScreen extends StatelessWidget{
             fit: BoxFit.cover,
           ),
         ),
-        child: CustomScrollView(
-          slivers: <Widget>[
-            SliverToBoxAdapter(child: UserCommunitiesList()),
-            SliverToBoxAdapter(child: CommunitySearchBar()),
-            CommunitySearchResults(),
-          ],
+        child: BaseDataWidget<CommunitySearchModel>(
+          model: CommunitySearchModel(api: Provider.of(context)),
+          onModelReady: (model) => { /* TODO mjf: fetch data */ },
+          builder: (context, communitySearch, child) =>
+            CustomScrollView(
+              slivers: <Widget>[
+                SliverToBoxAdapter(child: UserCommunitiesList()),
+                SliverToBoxAdapter(child: CommunitySearchBar(search: communitySearch.searchCommunities)),
+                CommunitySearchResults(communities: communitySearch.communities),
+              ],
+            ),
         ),
       ),
       bottomNavigationBar: BottomAppBar(


### PR DESCRIPTION
The two community screen child components each had an instance of the community search model so changes to one weren't affecting the other. I raised the ChangeNotifierProvider to the community screen so the child components would be notified of each other's actions.